### PR TITLE
Fixed indents and added 'local' keyword.

### DIFF
--- a/grammars/moonscript.json
+++ b/grammars/moonscript.json
@@ -87,7 +87,7 @@
       ]
     },
     {
-      "match": "(?x)\\b(?<![\\.\\$])(\\b(if|then|else|elseif|export|import|from|switch|and|or|not|when|with|using|do|for|in|while|return|unless|continue|break)\\b)(?!\\s*:)\\b",
+      "match": "(?x)\\b(?<![\\.\\$])(\\b(if|then|else|elseif|export|import|from|switch|and|or|not|when|with|using|do|for|in|while|return|unless|continue|break|local)\\b)(?!\\s*:)\\b",
       "name": "keyword.control.moon"
     },
     {

--- a/scoped-properties/language-moonscript.json
+++ b/scoped-properties/language-moonscript.json
@@ -1,8 +1,8 @@
 {
   ".source.moon": {
     "editor": {
-      "commentStart": "--",
-      "increaseIndentPattern": "\\b(else|elseif|then|do|repeat|switch|class|with|when)\\b((?!end).)*$|\\{\\s*|\\[\\s*|\\->|=>|\\w+\\s*\\=\\s*$",
+      "commentStart": "-- ",
+      "increaseIndentPattern": "\\b(if|for|while|unless|else|elseif|then|do|repeat|switch|class|with|when)\\b.*$|(\\{\\s*|\\[\\s*|\\->|=>|\\w+\\s*\\=\\s*|\\w+\\s*:\\s*)$",
       "decreaseIndentPattern": "^\\s*(elseif|else|\\}|\\])\\s*$"
     }
   }


### PR DESCRIPTION
Indentation was a little wonky. Before, it'd indent on lines such as this, where there was already an enclosed brace:
```moonscript
{ entry: 1, key: 'hello' }
```

I've fixed this along with adding indentation for keywords `if`, `for`, `while`, `unless`, and table keywords.

The local keyword was added as a detected keyword. See: [Local Statement](http://moonscript.org/reference/#local_statement)

And for readability, I made so the comment symbol has a space following it, like in Lua.